### PR TITLE
Expose the proper ports, create isolated user, add volume mountpoint, and fix startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,30 @@
-FROM lsiobase/xenial
+FROM ubuntu:xenial
+MAINTAINER sparkly[blue]balls
+
+# Websockets
+EXPOSE 42345
+EXPOSE 42346
+
+# Multicast Discovery
+EXPOSE 28914
 
 ARG DEBIAN_FRONTEND="noninteractive"
+              
+RUN apt-get update && \
+    apt-get install -y apt-transport-https && \
+    echo "deb https://releases.librevault.com/debian/ xenial/" >> /etc/apt/sources.list.d/librevault.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7ECABE6D2866013E2D9DB819F6CDDCEF4B158906 && \
+    apt-get update && \
+    apt-get install -y librevault && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* \
+           /var/tmp/* && \
+    mkdir /srv/librevault && \
+    useradd -m librevault && \
+    chmod 755 /srv/librevault && \
+    chown librevault:librevault /srv/librevault
 
-RUN \
-  apt-get update && \
-  apt-get install -y apt-transport-https && \
-  echo "deb https://releases.librevault.com/debian/ xenial/" >> /etc/apt/sources.list.d/librevault.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7ECABE6D2866013E2D9DB819F6CDDCEF4B158906 && \
-  apt-get update && \
-  apt-get install -y librevault && \
+# Isolate it away from root (just in case cuz you know stuffz is "always" secure)
+USER librevault
 
-  apt-get clean && \
-  rm -rf \
-	/var/lib/apt/lists/* \
-	/var/tmp/*
-
-COPY /root/ /
+ENTRYPOINT ["/usr/bin/librevault-daemon", "--data", "/srv/librevault"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:xenial
 MAINTAINER sparkly[blue]balls
 
+ARG DEBIAN_FRONTEND="noninteractive"
+ARG LIBREVAULT_VERSION="0.1.18-85+ubuntu16.04"
+
 # Websockets
 EXPOSE 42345
 EXPOSE 42346
@@ -8,23 +11,22 @@ EXPOSE 42346
 # Multicast Discovery
 EXPOSE 28914
 
-ARG DEBIAN_FRONTEND="noninteractive"
-              
+# Allow the main directory to be optionally mounted from the host for persistence
+VOLUME ["/srv/librevault"]
+
+COPY docker/ /
 RUN apt-get update && \
     apt-get install -y apt-transport-https && \
     echo "deb https://releases.librevault.com/debian/ xenial/" >> /etc/apt/sources.list.d/librevault.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7ECABE6D2866013E2D9DB819F6CDDCEF4B158906 && \
     apt-get update && \
-    apt-get install -y librevault && \
+    apt-get install -y librevault=${LIBREVAULT_VERSION} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \
            /var/tmp/* && \
-    mkdir /srv/librevault && \
     useradd -m librevault && \
-    chmod 755 /srv/librevault && \
+    chmod 755 /srv/librevault \
+              /usr/bin/start && \
     chown librevault:librevault /srv/librevault
 
-# Isolate it away from root (just in case cuz you know stuffz is "always" secure)
-USER librevault
-
-ENTRYPOINT ["/usr/bin/librevault-daemon", "--data", "/srv/librevault"]
+ENTRYPOINT ["/usr/bin/start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM ubuntu:xenial
-MAINTAINER sparkly[blue]balls
+FROM lsiobase/xenial
 
 ARG DEBIAN_FRONTEND="noninteractive"
+ARG LIBREVAULT_CONTROL_LISTEN=42346
+ARG LIBREVAULT_MULTICAST_GROUP=28914
+ARG LIBREVAULT_P2P_LISTEN=42345
 ARG LIBREVAULT_VERSION="0.1.18-85+ubuntu16.04"
 
-# Websockets
-EXPOSE 42345
-EXPOSE 42346
+EXPOSE ${LIBREVAULT_CONTROL_LISTEN} \
+       ${LIBREVAULT_CONTROL_MULTICAST_GROUP} \
+       ${LIBREVAULT_P2P_LISTEN}
 
-# Multicast Discovery
-EXPOSE 28914
-
-# Allow the main directory to be optionally mounted from the host for persistence
-VOLUME ["/srv/librevault"]
+# Allow the confiuration directory and the librevault data directory to be optionally mounted from the host for persistence
+VOLUME ["/home/librevault/.config/Librevault", "/srv/librevault"]
 
 COPY docker/ /
 RUN apt-get update && \
@@ -27,6 +26,7 @@ RUN apt-get update && \
     useradd -m librevault && \
     chmod 755 /srv/librevault \
               /usr/bin/start && \
-    chown librevault:librevault /srv/librevault
+    chown -R librevault:librevault /home/librevault/ \
+                                   /srv/librevault
 
 ENTRYPOINT ["/usr/bin/start"]

--- a/docker/usr/bin/start
+++ b/docker/usr/bin/start
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-chown -R librevault:librevault /srv/librevault
+chown -R librevault:librevault /home/librevault /srv/librevault
 
 exec su --command "/usr/bin/librevault-daemon --data /srv/librevault" --login librevault

--- a/docker/usr/bin/start
+++ b/docker/usr/bin/start
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+chown -R librevault:librevault /srv/librevault
+
+exec su --command "/usr/bin/librevault-daemon --data /srv/librevault" --login librevault

--- a/root/etc/services.d/librevault/run
+++ b/root/etc/services.d/librevault/run
@@ -1,4 +1,0 @@
-#!/usr/bin/with-contenv bash
-
-exec \
-	librevault-daemon


### PR DESCRIPTION
Run with:
// Build args are optional
docker build --build-arg LIBREVAULT_CONTROL_LISTEN=42346 --build-arg LIBREVAULT_MULTICAST_GROUP=28914 --build-arg LIBREVAULT_P2P_LISTEN=42345 --build-arg LIBREVAULT_VERSION=0.1.18-85+ubuntu16.04 -t librevault:0.1.18 ./

// Mounting the volume peristently on the host is optional
docker run -d -p 28914:28914 -p 42345:42345 -p 42346:42346  -v "/home/docker_user/.config/Librefault:/home/librevault/.config/Librevault" -v "/absolute/host/path:/srv/librevault" librevault:0.1.18

This should at least stay running and expose the necessary ports but I have not tested actual librevault functionality or if extra commands need to be run to make it work.

.config/Librevault takes the files specified at https://librevault.com/blog/librevault-config/
